### PR TITLE
 Add 6 new OCR engines for horizontal comparison benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/user-attachments/assets/57507c48-ec88-4d4a-bf68-067eefc9d42f
 
 ## Features
 
-- **Multiple OCR Engines**: Support for MacOCR (Apple Vision), EasyOCR, PaddleOCR, Florence-2, and TrOCR
+- **Multiple OCR Engines**: Support for MacOCR (Apple Vision), RapidOCR, EasyOCR, PaddleOCR, Florence-2, Google Cloud Vision, Gemini, and more
 - **Automatic Perspective Projection**: Converts equirectangular panoramas to multiple perspective views for better OCR accuracy
 - **Deduplication**: Automatically removes duplicate text detections across overlapping perspective views
 - **Spherical Coordinates**: Returns OCR results in yaw/pitch coordinates that map directly to the panorama
@@ -26,16 +26,29 @@ Install with OCR engine dependencies:
 # macOS (Apple Vision Framework)
 pip install "panoocr[macocr]"
 
+# RapidOCR (PP-OCRv4/v5 via ONNX Runtime, cross-platform)
+pip install "panoocr[rapidocr]"
+
 # EasyOCR (cross-platform)
 pip install "panoocr[easyocr]"
 
 # PaddleOCR (cross-platform)
 pip install "panoocr[paddleocr]"
 
-# Florence-2 (requires GPU recommended)
+# Florence-2 via transformers + torch (requires GPU recommended)
 pip install "panoocr[florence2]"
 
-# All engines (excluding platform-specific macocr)
+# MLX VLM engines: Florence-2 MLX, GLM-OCR, DOTS.OCR (macOS Apple Silicon)
+pip install "panoocr[mlx-vlm]"
+
+# Google Cloud Vision API (requires API key)
+pip install "panoocr[google-vision]"
+
+# Gemini API (requires API key)
+pip install "panoocr[gemini]"
+
+# Cross-platform local engines + visualization
+# (excludes macOS-only macocr, Apple Silicon mlx-vlm, cloud APIs, and experimental trocr)
 pip install "panoocr[full]"
 ```
 
@@ -43,7 +56,9 @@ Using uv (recommended):
 
 ```bash
 uv add panoocr
-uv add "panoocr[macocr]"  # or other extras
+uv sync --extra macocr      # or other extras
+uv sync --extra rapidocr
+uv sync --extra mlx-vlm     # Florence-2 MLX, GLM-OCR, DOTS.OCR
 ```
 
 ## Quick Start
@@ -73,53 +88,122 @@ for r in result.results:
 
 ## Available OCR Engines
 
-### MacOCREngine (macOS only)
+### Structured engines (return per-word bounding boxes)
+
+#### MacOCREngine (macOS only)
 
 Uses Apple's Vision Framework for fast, accurate OCR on macOS.
 
 ```python
-from panoocr.engines.macocr import MacOCREngine, MacOCRLanguageCode
+from panoocr.engines.macocr import MacOCREngine
 
-engine = MacOCREngine(config={
-    "language_preference": [MacOCRLanguageCode.ENGLISH_US],
-})
+engine = MacOCREngine()
 ```
 
-### EasyOCREngine
+#### RapidOCREngine
+
+PaddleOCR PP-OCRv4/v5 models via ONNX Runtime. Supports both v4 (2023) and v5 (2025) models, multilingual including CJK.
+
+```python
+from panoocr.engines.rapidocr_engine import RapidOCREngine
+
+engine_v4 = RapidOCREngine()                                     # default: PP-OCRv4
+engine_v5 = RapidOCREngine(config={"ocr_version": "PP-OCRv5"})   # PP-OCRv5
+```
+
+#### EasyOCREngine
 
 Cross-platform OCR supporting 80+ languages.
 
 ```python
-from panoocr.engines.easyocr import EasyOCREngine, EasyOCRLanguageCode
+from panoocr.engines.easyocr import EasyOCREngine
 
-engine = EasyOCREngine(config={
-    "language_preference": [EasyOCRLanguageCode.ENGLISH],
-    "gpu": True,
-})
+engine = EasyOCREngine(config={"language_preference": ["en"], "gpu": True})
 ```
 
-### PaddleOCREngine
+#### PaddleOCREngine
 
-PaddlePaddle-based OCR supporting multiple languages with automatic model management. Uses PP-OCRv5 by default.
+PaddlePaddle-based OCR supporting multiple languages with automatic model management.
 
 ```python
-from panoocr.engines.paddleocr import PaddleOCREngine, PaddleOCRLanguageCode
+from panoocr.engines.paddleocr import PaddleOCREngine
 
-engine = PaddleOCREngine(config={
-    "language_preference": PaddleOCRLanguageCode.CHINESE,
-})
+engine = PaddleOCREngine()
 ```
 
-### Florence2OCREngine
+#### GoogleVisionEngine
 
-Microsoft's Florence-2 vision-language model for OCR.
+Google Cloud Vision API (`TEXT_DETECTION`). Requires `GOOGLE_VISION_API_KEY` in environment or `.env`.
+
+```python
+from panoocr.engines.google_vision import GoogleVisionEngine
+
+engine = GoogleVisionEngine()
+```
+
+#### Florence2OCREngine (transformers + torch)
+
+Microsoft's Florence-2 vision-language model via transformers.
 
 ```python
 from panoocr.engines.florence2 import Florence2OCREngine
 
-engine = Florence2OCREngine(config={
-    "model_id": "microsoft/Florence-2-large",
-})
+engine = Florence2OCREngine()
+```
+
+#### Florence2MLXEngine (mlx-vlm, macOS Apple Silicon)
+
+Florence-2 via mlx-vlm with `<OCR_WITH_REGION>` for structured quad-box output. The only VLM engine that returns per-word bounding boxes.
+
+```python
+from panoocr.engines.florence2_mlx import Florence2MLXEngine
+
+engine = Florence2MLXEngine()
+```
+
+### Unstructured engines (return text without bounding boxes)
+
+These engines return text only. Each detection gets a full-image bounding box for crop-level attribution in the panoocr pipeline.
+
+#### GeminiEngine
+
+Google Gemini API. Supports multiple model variants. Requires `GOOGLE_GEMINI_API_KEY` in environment or `.env`.
+
+```python
+from panoocr.engines.gemini import GeminiEngine
+
+engine_flash = GeminiEngine(config={"model": "gemini-2.5-flash"})
+engine_pro = GeminiEngine(config={"model": "gemini-2.5-pro"})
+```
+
+#### GlmOCREngine (mlx-vlm, macOS Apple Silicon)
+
+GLM-OCR (0.9B) via mlx-vlm. Document-focused VLM -- limited effectiveness on scene text.
+
+```python
+from panoocr.engines.glm_ocr import GlmOCREngine
+
+engine = GlmOCREngine()
+```
+
+#### DotsOCREngine (mlx-vlm, macOS Apple Silicon)
+
+DOTS.OCR (2.9B) via mlx-vlm. Document layout parser -- limited effectiveness on scene text.
+
+```python
+from panoocr.engines.dots_ocr import DotsOCREngine
+
+engine = DotsOCREngine()
+```
+
+#### TrOCREngine (experimental)
+
+Microsoft's TrOCR transformer-based single-line OCR. Does not detect text regions -- treats the entire image as one text line. Experimental; consider other engines for panorama OCR.
+
+```python
+from panoocr.engines.trocr import TrOCREngine
+
+engine = TrOCREngine()
 ```
 
 ## Advanced Usage

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -8,7 +8,11 @@ PanoOCR uses dependency injection for OCR engines. Provide any object with a mat
     options:
       show_root_heading: true
 
-## MacOCREngine
+## Structured Engines
+
+Structured engines return per-word bounding boxes, enabling geographic text indexing.
+
+### MacOCREngine
 
 Uses Apple's Vision Framework for fast, accurate OCR on macOS. Requires the `[macocr]` extra.
 
@@ -23,7 +27,22 @@ pip install "panoocr[macocr]"
         - __init__
         - recognize
 
-## EasyOCREngine
+### RapidOCREngine
+
+PaddleOCR PP-OCRv4/v5 models via ONNX Runtime. Bypasses PaddlePaddle framework (avoids Apple Silicon issues). Supports v4 and v5 model versions. Requires the `[rapidocr]` extra.
+
+```bash
+pip install "panoocr[rapidocr]"
+```
+
+::: panoocr.engines.rapidocr_engine.RapidOCREngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+### EasyOCREngine
 
 Cross-platform OCR supporting 80+ languages. Requires the `[easyocr]` extra.
 
@@ -38,9 +57,9 @@ pip install "panoocr[easyocr]"
         - __init__
         - recognize
 
-## PaddleOCREngine
+### PaddleOCREngine
 
-PaddlePaddle-based OCR supporting multiple languages with automatic model management. Uses PP-OCRv5 by default. Requires the `[paddleocr]` extra (includes both `paddleocr` and `paddlepaddle`).
+PaddlePaddle-based OCR supporting multiple languages with automatic model management. Requires the `[paddleocr]` extra (includes both `paddleocr` and `paddlepaddle`).
 
 ```bash
 pip install "panoocr[paddleocr]"
@@ -53,9 +72,24 @@ pip install "panoocr[paddleocr]"
         - __init__
         - recognize
 
-## Florence2OCREngine
+### GoogleVisionEngine
 
-Microsoft's Florence-2 vision-language model for OCR. Requires the `[florence2]` extra.
+Google Cloud Vision API (`TEXT_DETECTION`). Uses REST API with an API key. Requires the `[google-vision]` extra and `GOOGLE_VISION_API_KEY` environment variable.
+
+```bash
+pip install "panoocr[google-vision]"
+```
+
+::: panoocr.engines.google_vision.GoogleVisionEngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+### Florence2OCREngine
+
+Microsoft's Florence-2 vision-language model via transformers + torch. Requires the `[florence2]` extra.
 
 ```bash
 pip install "panoocr[florence2]"
@@ -68,7 +102,71 @@ pip install "panoocr[florence2]"
         - __init__
         - recognize
 
-## TrOCREngine
+### Florence2MLXEngine
+
+Florence-2 via mlx-vlm with `<OCR_WITH_REGION>` structured output. The only VLM engine that returns per-word bounding boxes. Requires macOS Apple Silicon with the `[mlx-vlm]` extra, plus `torch` and `torchvision`.
+
+```bash
+pip install "panoocr[mlx-vlm]" torch torchvision
+```
+
+::: panoocr.engines.florence2_mlx.Florence2MLXEngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+## Unstructured Engines
+
+Unstructured engines return text without bounding boxes. Each detection gets a full-image bounding box for crop-level attribution in the panoocr pipeline.
+
+### GeminiEngine
+
+Google Gemini API (Gemini 2.5 Flash / Pro). Requires the `[gemini]` extra and `GOOGLE_GEMINI_API_KEY` environment variable.
+
+```bash
+pip install "panoocr[gemini]"
+```
+
+::: panoocr.engines.gemini.GeminiEngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+### GlmOCREngine
+
+GLM-OCR (0.9B) via mlx-vlm. Document-focused VLM with limited effectiveness on scene text. Requires macOS Apple Silicon with the `[mlx-vlm]` extra.
+
+```bash
+pip install "panoocr[mlx-vlm]" torch
+```
+
+::: panoocr.engines.glm_ocr.GlmOCREngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+### DotsOCREngine
+
+DOTS.OCR (2.9B) via mlx-vlm. Document layout parser with limited effectiveness on scene text. Requires macOS Apple Silicon with the `[mlx-vlm]` extra.
+
+```bash
+pip install "panoocr[mlx-vlm]" torch
+```
+
+::: panoocr.engines.dots_ocr.DotsOCREngine
+    options:
+      show_root_heading: true
+      members:
+        - __init__
+        - recognize
+
+### TrOCREngine (experimental)
 
 Microsoft's TrOCR transformer-based OCR. Requires the `[trocr]` extra.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,16 @@ pip install "panoocr @ git+https://github.com/yz3440/panoocr.git"
 # With MacOCR (macOS only)
 pip install "panoocr[macocr]"
 
+# With RapidOCR (PP-OCRv4/v5 via ONNX Runtime)
+pip install "panoocr[rapidocr]"
+
 # With EasyOCR (cross-platform)
 pip install "panoocr[easyocr]"
 
-# With all engines
+# With MLX VLMs (Florence-2 MLX, GLM-OCR, DOTS.OCR — macOS Apple Silicon)
+pip install "panoocr[mlx-vlm]" torch torchvision
+
+# Cross-platform local engines + visualization
 pip install "panoocr[full] @ git+https://github.com/yz3440/panoocr.git"
 ```
 

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -7,7 +7,11 @@ Usage:
     python multi_engine.py path/to/panorama.jpg
 
 Prerequisites:
-    pip install "panoocr[full]"  # Install all engines
+    pip install "panoocr[full]"       # Cross-platform local engines
+    pip install "panoocr[macocr]"     # macOS Apple Vision (optional)
+    pip install "panoocr[mlx-vlm]"    # MLX VLMs on Apple Silicon (optional)
+    pip install "panoocr[gemini]"     # Gemini API (optional, needs API key)
+    pip install "panoocr[google-vision]"  # Google Vision API (optional, needs API key)
 """
 
 import sys
@@ -21,31 +25,45 @@ def get_available_engines() -> Dict[str, Any]:
 
     try:
         from panoocr.engines.macocr import MacOCREngine
-
         engines["macocr"] = MacOCREngine()
-    except ImportError:
-        print("MacOCR not available (requires macOS)")
+    except (ImportError, Exception):
+        print("MacOCR not available (requires macOS + pip install 'panoocr[macocr]')")
+
+    try:
+        from panoocr.engines.rapidocr_engine import RapidOCREngine
+        engines["rapidocr_v4"] = RapidOCREngine()
+    except (ImportError, Exception):
+        print("RapidOCR not available (pip install 'panoocr[rapidocr]')")
 
     try:
         from panoocr.engines.easyocr import EasyOCREngine
-
         engines["easyocr"] = EasyOCREngine()
-    except ImportError:
+    except (ImportError, Exception):
         print("EasyOCR not available (pip install 'panoocr[easyocr]')")
 
     try:
         from panoocr.engines.paddleocr import PaddleOCREngine
-
         engines["paddleocr"] = PaddleOCREngine()
-    except ImportError:
+    except (ImportError, Exception):
         print("PaddleOCR not available (pip install 'panoocr[paddleocr]')")
 
     try:
-        from panoocr.engines.florence2 import Florence2OCREngine
+        from panoocr.engines.google_vision import GoogleVisionEngine
+        engines["google_vision"] = GoogleVisionEngine()
+    except (ImportError, Exception):
+        print("Google Vision not available (pip install 'panoocr[google-vision]')")
 
-        engines["florence2"] = Florence2OCREngine()
-    except ImportError:
-        print("Florence2 not available (pip install 'panoocr[florence2]')")
+    try:
+        from panoocr.engines.florence2_mlx import Florence2MLXEngine
+        engines["florence2_mlx"] = Florence2MLXEngine()
+    except (ImportError, Exception):
+        print("Florence-2 MLX not available (pip install 'panoocr[mlx-vlm]' torch torchvision)")
+
+    try:
+        from panoocr.engines.gemini import GeminiEngine
+        engines["gemini_flash"] = GeminiEngine(config={"model": "gemini-2.5-flash"})
+    except (ImportError, Exception):
+        print("Gemini not available (pip install 'panoocr[gemini]')")
 
     return engines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,28 @@ viz = [
     "matplotlib>=3.7.0",
     "scipy>=1.10.0",
 ]
-# Full install with all features (excluding platform-specific macocr)
-full = ["panoocr[easyocr,paddleocr,florence2,viz]"]
+# RapidOCR engine (PP-OCRv4/v5 via ONNX Runtime)
+rapidocr = [
+    "rapidocr",
+    "onnxruntime",
+]
+# Google Cloud Vision API engine (uses REST API with API key)
+google-vision = [
+    "requests>=2.28.0",
+]
+# MLX VLM engines (Florence-2 MLX, GLM-OCR, DOTS.OCR)
+mlx-vlm = [
+    "mlx-vlm",
+    "torch>=2.0.0",
+    "torchvision",
+]
+# Gemini API engine
+gemini = [
+    "google-genai",
+]
+# Local cross-platform engines + visualization (excludes macOS-only macocr,
+# Apple Silicon mlx-vlm, cloud APIs google-vision/gemini, and experimental trocr)
+full = ["panoocr[easyocr,paddleocr,florence2,rapidocr,viz]"]
 # Documentation dependencies - install with: pip install "panoocr[docs]"
 docs = [
     "mkdocs>=1.5.0",

--- a/src/panoocr/__init__.py
+++ b/src/panoocr/__init__.py
@@ -15,13 +15,17 @@ Example:
 
 Install OCR engine dependencies:
     - MacOCR (macOS): pip install "panoocr[macocr]"
+    - RapidOCR: pip install "panoocr[rapidocr]"
     - EasyOCR: pip install "panoocr[easyocr]"
     - PaddleOCR: pip install "panoocr[paddleocr]"
-    - Florence-2: pip install "panoocr[florence2]"
-    - All engines: pip install "panoocr[full]"
+    - Florence-2 (torch): pip install "panoocr[florence2]"
+    - MLX VLMs (Florence-2 MLX, GLM-OCR, DOTS.OCR): pip install "panoocr[mlx-vlm]"
+    - Google Cloud Vision: pip install "panoocr[google-vision]"
+    - Gemini: pip install "panoocr[gemini]"
+    - Cross-platform local engines: pip install "panoocr[full]"
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # Pipeline-first public API
 from .api import (

--- a/src/panoocr/engines/__init__.py
+++ b/src/panoocr/engines/__init__.py
@@ -7,42 +7,61 @@ Available engines:
 - MacOCREngine: Uses Apple Vision Framework (macOS only)
 - EasyOCREngine: Uses EasyOCR library
 - PaddleOCREngine: Uses PaddleOCR library
-- Florence2OCREngine: Uses Microsoft Florence-2 model
+- Florence2OCREngine: Uses Microsoft Florence-2 model (transformers + torch)
 - TrOCREngine: Uses Microsoft TrOCR model (experimental)
+- RapidOCREngine: Uses PP-OCRv4/v5 via ONNX Runtime
+- GoogleVisionEngine: Uses Google Cloud Vision API (TEXT_DETECTION)
+- Florence2MLXEngine: Uses Florence-2 via mlx-vlm (structured, with bboxes)
+- GlmOCREngine: Uses GLM-OCR via mlx-vlm (unstructured)
+- DotsOCREngine: Uses DOTS.OCR via mlx-vlm (unstructured)
+- GeminiEngine: Uses Gemini API (unstructured)
 
 Install the required dependencies for each engine:
-- MacOCR: pip install "panoocr[macocr]"
-- EasyOCR: pip install "panoocr[easyocr]"
-- PaddleOCR: pip install "panoocr[paddleocr]"
-- Florence-2: pip install "panoocr[florence2]"
-- TrOCR: pip install "panoocr[trocr]"
+- MacOCR: uv sync --extra macocr
+- EasyOCR: uv sync --extra easyocr
+- PaddleOCR: uv sync --extra paddleocr
+- Florence-2 (torch): uv sync --extra florence2
+- TrOCR: uv sync --extra trocr
+- RapidOCR: uv sync --extra rapidocr
+- Google Vision: uv sync --extra google-vision
+- Florence-2 MLX / GLM-OCR / DOTS.OCR: uv sync --extra mlx-vlm
+- Gemini: uv sync --extra gemini
 """
 
-# Engines are imported lazily to avoid requiring all dependencies
 __all__ = [
     "MacOCREngine",
     "EasyOCREngine",
     "PaddleOCREngine",
     "Florence2OCREngine",
     "TrOCREngine",
+    "RapidOCREngine",
+    "GoogleVisionEngine",
+    "Florence2MLXEngine",
+    "GlmOCREngine",
+    "DotsOCREngine",
+    "GeminiEngine",
 ]
+
+_LAZY_IMPORTS = {
+    "MacOCREngine": (".macocr", "MacOCREngine"),
+    "EasyOCREngine": (".easyocr", "EasyOCREngine"),
+    "PaddleOCREngine": (".paddleocr", "PaddleOCREngine"),
+    "Florence2OCREngine": (".florence2", "Florence2OCREngine"),
+    "TrOCREngine": (".trocr", "TrOCREngine"),
+    "RapidOCREngine": (".rapidocr_engine", "RapidOCREngine"),
+    "GoogleVisionEngine": (".google_vision", "GoogleVisionEngine"),
+    "Florence2MLXEngine": (".florence2_mlx", "Florence2MLXEngine"),
+    "GlmOCREngine": (".glm_ocr", "GlmOCREngine"),
+    "DotsOCREngine": (".dots_ocr", "DotsOCREngine"),
+    "GeminiEngine": (".gemini", "GeminiEngine"),
+}
 
 
 def __getattr__(name: str):
     """Lazy import engines to avoid loading unnecessary dependencies."""
-    if name == "MacOCREngine":
-        from .macocr import MacOCREngine
-        return MacOCREngine
-    elif name == "EasyOCREngine":
-        from .easyocr import EasyOCREngine
-        return EasyOCREngine
-    elif name == "PaddleOCREngine":
-        from .paddleocr import PaddleOCREngine
-        return PaddleOCREngine
-    elif name == "Florence2OCREngine":
-        from .florence2 import Florence2OCREngine
-        return Florence2OCREngine
-    elif name == "TrOCREngine":
-        from .trocr import TrOCREngine
-        return TrOCREngine
+    if name in _LAZY_IMPORTS:
+        module_path, class_name = _LAZY_IMPORTS[name]
+        import importlib
+        module = importlib.import_module(module_path, __name__)
+        return getattr(module, class_name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/panoocr/engines/dots_ocr.py
+++ b/src/panoocr/engines/dots_ocr.py
@@ -1,0 +1,107 @@
+"""DOTS.OCR Engine using mlx-vlm.
+
+Document-focused VLM (2.9B params) from RedNote. Included as a second
+document-domain-mismatch data point alongside GLM-OCR.
+Returns unstructured text (no bounding boxes).
+
+Install with: pip install "panoocr[mlx-vlm]" torch
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any, Dict, List
+
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+_FULL_IMAGE_BBOX = BoundingBox(
+    left=0.0, top=0.0, right=1.0, bottom=1.0, width=1.0, height=1.0
+)
+
+DEFAULT_PROMPT = (
+    "Extract all visible text from this image. "
+    "Return each text fragment on its own line, exactly as it appears."
+)
+
+
+def _check_dots_ocr_dependencies():
+    try:
+        import mlx_vlm
+    except ImportError:
+        raise ImportError(
+            "DOTS.OCR dependencies not installed.\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[mlx-vlm]' torch"
+        )
+
+
+class DotsOCREngine:
+    """OCR engine using DOTS.OCR (2.9B) via mlx-vlm.
+
+    This is an unstructured engine -- it returns text without bounding boxes.
+    Each text line gets a full-image bounding box for crop-level attribution.
+
+    Example:
+        >>> from panoocr.engines.dots_ocr import DotsOCREngine
+        >>> engine = DotsOCREngine()
+        >>> results = engine.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[mlx-vlm]" torch
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_dots_ocr_dependencies()
+
+        from mlx_vlm import load
+
+        config = config or {}
+        model_id = config.get("model_id", "mlx-community/dots.ocr-4bit")
+        self.max_tokens = config.get("max_tokens", 512)
+        self.prompt = config.get("prompt", DEFAULT_PROMPT)
+
+        print(f"Loading DOTS.OCR model: {model_id}...")
+        self.model, self.processor = load(model_id)
+        print("DOTS.OCR model loaded.")
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        from mlx_vlm import generate
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            image.save(f, format="JPEG")
+            tmp_path = f.name
+
+        try:
+            result = generate(
+                self.model,
+                self.processor,
+                image=tmp_path,
+                prompt=self.prompt,
+                max_tokens=self.max_tokens,
+                verbose=False,
+            )
+        finally:
+            import os
+            os.unlink(tmp_path)
+
+        output_text = result.text if hasattr(result, "text") else str(result)
+
+        results = []
+        for line in output_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("```") or line.startswith("---"):
+                continue
+            results.append(
+                FlatOCRResult(
+                    text=line,
+                    confidence=1.0,
+                    bounding_box=_FULL_IMAGE_BBOX,
+                    engine="DOTS_OCR",
+                )
+            )
+
+        return results

--- a/src/panoocr/engines/florence2.py
+++ b/src/panoocr/engines/florence2.py
@@ -12,7 +12,6 @@ import gc
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-import numpy as np
 from PIL import Image
 
 from ..ocr.models import BoundingBox, FlatOCRResult

--- a/src/panoocr/engines/florence2_mlx.py
+++ b/src/panoocr/engines/florence2_mlx.py
@@ -1,0 +1,205 @@
+"""Florence-2 MLX Engine using mlx-vlm.
+
+Uses the MLX-optimized Florence-2 model with <OCR_WITH_REGION> task
+to get structured text + bounding box output.
+
+Install with: pip install "panoocr[mlx-vlm]" torch
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+
+def _check_florence2_mlx_dependencies():
+    missing = []
+    try:
+        import mlx_vlm
+    except ImportError:
+        missing.append("mlx-vlm")
+    try:
+        import torch
+    except ImportError:
+        missing.append("torch")
+    try:
+        import torchvision
+    except ImportError:
+        missing.append("torchvision")
+    if missing:
+        raise ImportError(
+            f"Florence-2 MLX dependencies not installed: {', '.join(missing)}\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[mlx-vlm]' torch torchvision"
+        )
+
+
+def _patch_florence2_config():
+    """Patch config loading for transformers 5.x + Florence-2 MLX compatibility.
+
+    The MLX model's config.json references 'florence2_language' as a model_type
+    for its text_config, which isn't registered in transformers 5.x CONFIG_MAPPING.
+    We register BartConfig as a stand-in (Florence-2's language model is BART-based).
+    We also disable remote code loading to avoid stale cached custom code.
+    """
+    import os
+    os.environ["TRANSFORMERS_NO_REMOTE_CODE"] = "1"
+
+    from transformers import CONFIG_MAPPING
+    from transformers.models.bart.configuration_bart import BartConfig
+
+    try:
+        CONFIG_MAPPING.register("florence2_language", BartConfig)
+    except ValueError:
+        pass  # already registered
+
+
+def _parse_ocr_with_region(text: str, image_width: int, image_height: int):
+    """Parse Florence-2 <OCR_WITH_REGION> raw output into structured results.
+
+    Florence-2 returns text like:
+      TEXT1<loc_x1><loc_y1><loc_x2><loc_y2><loc_x3><loc_y3><loc_x4><loc_y4>TEXT2<loc_...>
+    where loc values are 0-999 normalized coordinates forming quad-boxes.
+    """
+    results = []
+    loc_pattern = r'<loc_(\d+)>'
+
+    # Split text at sequences of <loc_...> tokens
+    # Each detection is: label text followed by 8 loc tokens (quad-box)
+    parts = re.split(r'((?:<loc_\d+>)+)', text)
+
+    i = 0
+    while i < len(parts) - 1:
+        label = parts[i].strip()
+        if i + 1 < len(parts):
+            locs = [int(m) for m in re.findall(loc_pattern, parts[i + 1])]
+        else:
+            locs = []
+        i += 2
+
+        if not label or len(locs) < 4:
+            continue
+
+        if len(locs) == 8:
+            coords = [(locs[j], locs[j + 1]) for j in range(0, 8, 2)]
+        elif len(locs) == 4:
+            x1, y1, x2, y2 = locs
+            coords = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+        else:
+            # Take first 4 as x1,y1,x2,y2
+            x1, y1, x2, y2 = locs[0], locs[1], locs[2], locs[3]
+            coords = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+
+        px_coords = [
+            (c[0] / 999.0 * image_width, c[1] / 999.0 * image_height)
+            for c in coords
+        ]
+
+        results.append((label, px_coords))
+
+    return results
+
+
+@dataclass
+class Florence2MLXResult:
+    """Raw result from Florence-2 MLX."""
+
+    text: str
+    bounding_box: List[tuple]  # 4 corner points in pixel coords
+    image_width: int
+    image_height: int
+
+    def to_flat(self) -> FlatOCRResult:
+        left = min(p[0] for p in self.bounding_box)
+        right = max(p[0] for p in self.bounding_box)
+        top = min(p[1] for p in self.bounding_box)
+        bottom = max(p[1] for p in self.bounding_box)
+
+        return FlatOCRResult(
+            text=self.text,
+            confidence=1.0,
+            bounding_box=BoundingBox(
+                left=left / self.image_width,
+                top=top / self.image_height,
+                right=right / self.image_width,
+                bottom=bottom / self.image_height,
+                width=(right - left) / self.image_width,
+                height=(bottom - top) / self.image_height,
+            ),
+            engine="FLORENCE_2_MLX",
+        )
+
+
+class Florence2MLXEngine:
+    """OCR engine using Florence-2 via mlx-vlm with <OCR_WITH_REGION>.
+
+    This is a structured engine -- it returns per-word bounding boxes.
+
+    Example:
+        >>> from panoocr.engines.florence2_mlx import Florence2MLXEngine
+        >>> engine = Florence2MLXEngine()
+        >>> results = engine.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[mlx-vlm]" torch
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_florence2_mlx_dependencies()
+        _patch_florence2_config()
+
+        from mlx_vlm import load
+
+        config = config or {}
+        model_id = config.get("model_id", "mlx-community/Florence-2-large-ft-8bit")
+        self.max_tokens = config.get("max_tokens", 1024)
+
+        print(f"Loading Florence-2 MLX model: {model_id}...")
+        self.model, self.processor = load(model_id, trust_remote_code=False)
+        print("Florence-2 MLX model loaded.")
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        from mlx_vlm import generate
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            image.save(f, format="JPEG")
+            tmp_path = f.name
+
+        try:
+            result = generate(
+                self.model,
+                self.processor,
+                image=tmp_path,
+                prompt="<OCR_WITH_REGION>",
+                max_tokens=self.max_tokens,
+                verbose=False,
+            )
+        finally:
+            import os
+            os.unlink(tmp_path)
+
+        output_text = result.text if hasattr(result, "text") else str(result)
+        parsed = _parse_ocr_with_region(output_text, image.width, image.height)
+
+        results = []
+        for label, coords in parsed:
+            xs = [c[0] for c in coords]
+            ys = [c[1] for c in coords]
+            if max(xs) - min(xs) < 1 and max(ys) - min(ys) < 1:
+                continue
+            results.append(
+                Florence2MLXResult(
+                    text=label,
+                    bounding_box=coords,
+                    image_width=image.width,
+                    image_height=image.height,
+                )
+            )
+
+        return [r.to_flat() for r in results]

--- a/src/panoocr/engines/gemini.py
+++ b/src/panoocr/engines/gemini.py
@@ -1,0 +1,205 @@
+"""Gemini API Engine using google-genai.
+
+Frontier VLM for OCR accuracy ceiling measurement.
+Returns structured text with bounding boxes via spatial grounding.
+
+Install with: pip install "panoocr[gemini]"
+Requires GOOGLE_GEMINI_API_KEY environment variable.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+_FULL_IMAGE_BBOX = BoundingBox(
+    left=0.0, top=0.0, right=1.0, bottom=1.0, width=1.0, height=1.0
+)
+
+BBOX_PROMPT = (
+    "For each piece of text visible in this image, return a JSON array "
+    "where each element has:\n"
+    '- "text": the text string exactly as it appears\n'
+    '- "box": [y1, x1, y2, x2] normalized bounding box coordinates (0-1000)\n'
+    "\n"
+    "Include partial, blurry, or small text. Do not interpret or correct spelling.\n"
+    "Return ONLY the JSON array, no other text."
+)
+
+PLAIN_PROMPT = (
+    "Extract all visible text from this street-level image. "
+    "Return each text fragment on its own line, exactly as it appears. "
+    "Include partial, blurry, or small text. Do not interpret or correct spelling."
+)
+
+
+def _check_gemini_dependencies():
+    try:
+        import google.genai
+    except ImportError:
+        raise ImportError(
+            "Gemini dependencies not installed.\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[gemini]'\n\n"
+            "Also set GOOGLE_GEMINI_API_KEY environment variable."
+        )
+
+
+def _parse_bbox_response(text: str, engine_tag: str) -> List[FlatOCRResult]:
+    """Parse Gemini JSON bbox response into FlatOCRResults."""
+    text = text.strip()
+    json_match = re.search(r'\[.*\]', text, re.DOTALL)
+    if not json_match:
+        return []
+
+    try:
+        items = json.loads(json_match.group())
+    except json.JSONDecodeError:
+        return []
+
+    results = []
+    for item in items:
+        txt = item.get("text", "").strip()
+        box = item.get("box", [])
+        if not txt or len(box) != 4:
+            continue
+
+        # Gemini returns [y1, x1, y2, x2] in 0-1000 range
+        y1, x1, y2, x2 = [v / 1000.0 for v in box]
+        if y1 > y2:
+            y1, y2 = y2, y1
+        if x1 > x2:
+            x1, x2 = x2, x1
+
+        results.append(FlatOCRResult(
+            text=txt,
+            confidence=1.0,
+            bounding_box=BoundingBox(
+                left=x1, top=y1, right=x2, bottom=y2,
+                width=x2 - x1, height=y2 - y1,
+            ),
+            engine=engine_tag,
+        ))
+
+    return results
+
+
+class GeminiEngine:
+    """OCR engine using Gemini API with spatial grounding.
+
+    Returns structured text with per-detection bounding boxes by default.
+    Set config "use_bbox" to False for plain text mode (crop-level attribution).
+
+    Example:
+        >>> from panoocr.engines.gemini import GeminiEngine
+        >>> engine = GeminiEngine(config={"model": "gemini-2.5-flash"})
+        >>> results = engine.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[gemini]"
+        Requires GOOGLE_GEMINI_API_KEY environment variable.
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_gemini_dependencies()
+
+        from google import genai
+
+        config = config or {}
+
+        self._load_dotenv()
+
+        api_key = config.get(
+            "api_key",
+            os.environ.get("GOOGLE_GEMINI_API_KEY",
+                os.environ.get("GEMINI_API_KEY",
+                    os.environ.get("GOOGLE_API_KEY"))),
+        )
+        if not api_key:
+            raise ValueError(
+                "Gemini API key not found. Set GOOGLE_GEMINI_API_KEY, "
+                "GEMINI_API_KEY, or GOOGLE_API_KEY environment variable, "
+                "or pass api_key in config."
+            )
+
+        self.client = genai.Client(api_key=api_key)
+        self.model_name = config.get("model", "gemini-2.5-pro")
+        self.use_bbox = config.get("use_bbox", True)
+
+        if self.use_bbox:
+            self.prompt = config.get("prompt", BBOX_PROMPT)
+        else:
+            self.prompt = config.get("prompt", PLAIN_PROMPT)
+
+        if "flash" in self.model_name:
+            self._engine_tag = "GEMINI_2_5_FLASH"
+        elif "pro" in self.model_name:
+            self._engine_tag = "GEMINI_2_5_PRO"
+        else:
+            self._engine_tag = "GEMINI"
+
+    @staticmethod
+    def _load_dotenv():
+        try:
+            from pathlib import Path
+
+            env_path = Path(".env")
+            if not env_path.exists():
+                env_path = Path(__file__).resolve().parents[3] / ".env"
+            if env_path.exists():
+                for line in env_path.read_text().splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        key, _, value = line.partition("=")
+                        os.environ.setdefault(key.strip(), value.strip())
+        except Exception:
+            pass
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        from google.genai import types
+
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=90)
+        image_bytes = buf.getvalue()
+
+        response = self.client.models.generate_content(
+            model=self.model_name,
+            contents=[
+                types.Content(
+                    parts=[
+                        types.Part.from_bytes(data=image_bytes, mime_type="image/jpeg"),
+                        types.Part.from_text(text=self.prompt),
+                    ]
+                )
+            ],
+        )
+
+        output_text = response.text or ""
+
+        if self.use_bbox:
+            return _parse_bbox_response(output_text, self._engine_tag)
+
+        results = []
+        for line in output_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("```") or line.startswith("---"):
+                continue
+            results.append(
+                FlatOCRResult(
+                    text=line,
+                    confidence=1.0,
+                    bounding_box=_FULL_IMAGE_BBOX,
+                    engine=self._engine_tag,
+                )
+            )
+
+        return results

--- a/src/panoocr/engines/glm_ocr.py
+++ b/src/panoocr/engines/glm_ocr.py
@@ -1,0 +1,108 @@
+"""GLM-OCR Engine using mlx-vlm.
+
+Document-focused VLM (0.9B params) from Zhipu AI. Included as a
+domain-mismatch control -- trained on documents, not scene text.
+Returns unstructured text (no bounding boxes).
+
+Install with: pip install "panoocr[mlx-vlm]" torch
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any, Dict, List
+
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+_FULL_IMAGE_BBOX = BoundingBox(
+    left=0.0, top=0.0, right=1.0, bottom=1.0, width=1.0, height=1.0
+)
+
+DEFAULT_PROMPT = (
+    "Extract all visible text from this image. "
+    "Return each text fragment on its own line, exactly as it appears."
+)
+
+
+def _check_glm_ocr_dependencies():
+    try:
+        import mlx_vlm
+    except ImportError:
+        raise ImportError(
+            "GLM-OCR dependencies not installed.\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[mlx-vlm]' torch"
+        )
+
+
+class GlmOCREngine:
+    """OCR engine using GLM-OCR (0.9B) via mlx-vlm.
+
+    This is an unstructured engine -- it returns text without bounding boxes.
+    Each text line gets a full-image bounding box for crop-level attribution.
+
+    Example:
+        >>> from panoocr.engines.glm_ocr import GlmOCREngine
+        >>> engine = GlmOCREngine()
+        >>> results = engine.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[mlx-vlm]" torch
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_glm_ocr_dependencies()
+
+        from mlx_vlm import load
+
+        config = config or {}
+        model_id = config.get("model_id", "mlx-community/GLM-OCR-4bit")
+        self.max_tokens = config.get("max_tokens", 512)
+        self.prompt = config.get("prompt", DEFAULT_PROMPT)
+
+        print(f"Loading GLM-OCR model: {model_id}...")
+        self.model, self.processor = load(model_id)
+        print("GLM-OCR model loaded.")
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        from mlx_vlm import generate
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            image.save(f, format="JPEG")
+            tmp_path = f.name
+
+        try:
+            result = generate(
+                self.model,
+                self.processor,
+                image=tmp_path,
+                prompt=self.prompt,
+                max_tokens=self.max_tokens,
+                verbose=False,
+            )
+        finally:
+            import os
+            os.unlink(tmp_path)
+
+        output_text = result.text if hasattr(result, "text") else str(result)
+
+        results = []
+        for line in output_text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # Skip markdown artifacts from VLM output
+            if line.startswith("```") or line.startswith("---"):
+                continue
+            results.append(
+                FlatOCRResult(
+                    text=line,
+                    confidence=1.0,
+                    bounding_box=_FULL_IMAGE_BBOX,
+                    engine="GLM_OCR",
+                )
+            )
+
+        return results

--- a/src/panoocr/engines/google_vision.py
+++ b/src/panoocr/engines/google_vision.py
@@ -1,0 +1,178 @@
+"""Google Cloud Vision API Engine.
+
+Uses the REST API with an API key for TEXT_DETECTION (scene text).
+Requires GOOGLE_VISION_API_KEY environment variable or passed via config.
+
+Install with: pip install "panoocr[google-vision]"
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+VISION_API_URL = "https://vision.googleapis.com/v1/images:annotate"
+
+
+def _check_google_vision_dependencies():
+    try:
+        import requests
+    except ImportError:
+        raise ImportError(
+            "Google Vision dependencies not installed.\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[google-vision]'\n\n"
+            "Also set GOOGLE_VISION_API_KEY environment variable."
+        )
+
+
+@dataclass
+class GoogleVisionResult:
+    """Raw result from Google Cloud Vision TEXT_DETECTION."""
+
+    text: str
+    vertices: List[Dict[str, int]]  # [{"x": int, "y": int}, ...]
+    image_width: int
+    image_height: int
+
+    def to_flat(self) -> FlatOCRResult:
+        """Convert to FlatOCRResult with normalized coordinates."""
+        xs = [v.get("x", 0) for v in self.vertices]
+        ys = [v.get("y", 0) for v in self.vertices]
+        left = min(xs)
+        right = max(xs)
+        top = min(ys)
+        bottom = max(ys)
+
+        return FlatOCRResult(
+            text=self.text,
+            confidence=1.0,  # TEXT_DETECTION doesn't return per-word confidence by default
+            bounding_box=BoundingBox(
+                left=left / self.image_width,
+                top=top / self.image_height,
+                right=right / self.image_width,
+                bottom=bottom / self.image_height,
+                width=(right - left) / self.image_width,
+                height=(bottom - top) / self.image_height,
+            ),
+            engine="GOOGLE_CLOUD_VISION",
+        )
+
+
+class GoogleVisionEngine:
+    """OCR engine using Google Cloud Vision API (TEXT_DETECTION).
+
+    Uses the REST API with an API key. Set GOOGLE_VISION_API_KEY
+    in environment or .env file, or pass via config.
+
+    Example:
+        >>> from panoocr.engines.google_vision import GoogleVisionEngine
+        >>>
+        >>> engine = GoogleVisionEngine()
+        >>> results = engine.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[google-vision]"
+        Requires GOOGLE_VISION_API_KEY environment variable.
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_google_vision_dependencies()
+
+        config = config or {}
+
+        self._load_dotenv()
+
+        self.api_key = config.get(
+            "api_key",
+            os.environ.get("GOOGLE_VISION_API_KEY"),
+        )
+        if not self.api_key:
+            raise ValueError(
+                "Google Vision API key not found. Set GOOGLE_VISION_API_KEY "
+                "environment variable or pass api_key in config."
+            )
+
+    @staticmethod
+    def _load_dotenv():
+        """Try to load .env file from project root."""
+        try:
+            from pathlib import Path
+
+            env_path = Path(".env")
+            if not env_path.exists():
+                env_path = Path(__file__).resolve().parents[3] / ".env"
+            if env_path.exists():
+                for line in env_path.read_text().splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        key, _, value = line.partition("=")
+                        os.environ.setdefault(key.strip(), value.strip())
+        except Exception:
+            pass
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        """Recognize text in an image via Google Cloud Vision API.
+
+        Args:
+            image: Input image as PIL Image.
+
+        Returns:
+            List of FlatOCRResult with normalized bounding boxes.
+        """
+        import requests
+
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=90)
+        image_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        payload = {
+            "requests": [
+                {
+                    "image": {"content": image_b64},
+                    "features": [{"type": "TEXT_DETECTION"}],
+                }
+            ]
+        }
+
+        response = requests.post(
+            VISION_API_URL,
+            params={"key": self.api_key},
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        annotations = (
+            data.get("responses", [{}])[0].get("textAnnotations", [])
+        )
+
+        if len(annotations) <= 1:
+            return []
+
+        # annotations[0] is the full text block; [1:] are individual words
+        results = []
+        for ann in annotations[1:]:
+            text = ann.get("description", "")
+            vertices = ann.get("boundingPoly", {}).get("vertices", [])
+            if not text.strip() or len(vertices) < 3:
+                continue
+
+            results.append(
+                GoogleVisionResult(
+                    text=text,
+                    vertices=vertices,
+                    image_width=image.width,
+                    image_height=image.height,
+                )
+            )
+
+        return [r.to_flat() for r in results]

--- a/src/panoocr/engines/rapidocr_engine.py
+++ b/src/panoocr/engines/rapidocr_engine.py
@@ -1,0 +1,134 @@
+"""RapidOCR Engine using PP-OCRv4/v5 via ONNX Runtime.
+
+This module provides OCR using PaddleOCR's models converted to ONNX,
+running via ONNX Runtime. Bypasses PaddlePaddle framework entirely,
+avoiding documented freeze/crash issues on Apple Silicon.
+
+Supports both PP-OCRv4 (default) and PP-OCRv5 via config.
+
+Install with: pip install "panoocr[rapidocr]"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import numpy as np
+from PIL import Image
+
+from ..ocr.models import BoundingBox, FlatOCRResult
+
+
+def _check_rapidocr_dependencies():
+    try:
+        import rapidocr
+    except ImportError:
+        raise ImportError(
+            "RapidOCR dependencies not installed.\n\n"
+            "Install with:\n"
+            "  pip install 'panoocr[rapidocr]'\n\n"
+            "Also requires onnxruntime:\n"
+            "  pip install onnxruntime"
+        )
+
+
+@dataclass
+class RapidOCRResult:
+    """Raw result from RapidOCR."""
+
+    text: str
+    bounding_box: np.ndarray  # shape (4, 2) — 4-point polygon in pixel coords
+    confidence: float
+    image_width: int
+    image_height: int
+
+    def to_flat(self, engine_tag: str) -> FlatOCRResult:
+        """Convert to FlatOCRResult with normalized coordinates."""
+        left = float(self.bounding_box[:, 0].min())
+        right = float(self.bounding_box[:, 0].max())
+        top = float(self.bounding_box[:, 1].min())
+        bottom = float(self.bounding_box[:, 1].max())
+
+        return FlatOCRResult(
+            text=self.text,
+            confidence=self.confidence,
+            bounding_box=BoundingBox(
+                left=left / self.image_width,
+                top=top / self.image_height,
+                right=right / self.image_width,
+                bottom=bottom / self.image_height,
+                width=(right - left) / self.image_width,
+                height=(bottom - top) / self.image_height,
+            ),
+            engine=engine_tag,
+        )
+
+
+class RapidOCREngine:
+    """OCR engine using RapidOCR (PP-OCRv4/v5 via ONNX Runtime).
+
+    Attributes:
+        ocr_version: Which PP-OCR model version to use ("PP-OCRv4" or "PP-OCRv5").
+
+    Example:
+        >>> from panoocr.engines.rapidocr_engine import RapidOCREngine
+        >>>
+        >>> engine_v4 = RapidOCREngine()
+        >>> engine_v5 = RapidOCREngine(config={"ocr_version": "PP-OCRv5"})
+        >>> results = engine_v4.recognize(image)
+
+    Note:
+        Install with: pip install "panoocr[rapidocr]" onnxruntime
+    """
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        _check_rapidocr_dependencies()
+
+        from rapidocr import RapidOCR, OCRVersion
+
+        config = config or {}
+        version_str = config.get("ocr_version", "PP-OCRv4")
+
+        params: Dict[str, Any] = {}
+
+        if version_str == "PP-OCRv5":
+            params["Rec.ocr_version"] = OCRVersion.PPOCRV5
+            self._engine_tag = "RAPID_OCR_V5"
+        else:
+            self._engine_tag = "RAPID_OCR_V4"
+
+        self.ocr = RapidOCR(params=params if params else None)
+        self.ocr_version = version_str
+
+    def recognize(self, image: Image.Image) -> List[FlatOCRResult]:
+        """Recognize text in an image.
+
+        Args:
+            image: Input image as PIL Image.
+
+        Returns:
+            List of FlatOCRResult with normalized bounding boxes.
+        """
+        image_array = np.array(image)
+        result = self.ocr(image_array)
+
+        if not result or len(result) == 0:
+            return []
+
+        rapid_results = []
+        for box, txt, score in zip(result.boxes, result.txts, result.scores):
+            if not txt or not txt.strip():
+                continue
+
+            rapid_results.append(
+                RapidOCRResult(
+                    text=txt,
+                    bounding_box=box,
+                    confidence=float(score),
+                    image_width=image.width,
+                    image_height=image.height,
+                )
+            )
+
+        return [r.to_flat(self._engine_tag) for r in rapid_results]


### PR DESCRIPTION
## Summary
- Add 6 new OCR engine backends: RapidOCR (PP-OCRv4/v5), Google Cloud Vision, Florence-2 MLX, GLM-OCR, DOTS.OCR, and Gemini (2.5 Flash / Pro)
- Update documentation, `pyproject.toml` optional dependencies, and lazy import wiring for all new engines
- Clean up unused imports, sync version to 0.4.1, fix `[full]` extra wording
## New engines
| Engine | File | Type | Backend | Bbox |
|--------|------|------|---------|------|
| RapidOCREngine | `rapidocr_engine.py` | Traditional | ONNX Runtime (PP-OCRv4/v5) | Yes |
| GoogleVisionEngine | `google_vision.py` | Cloud API | REST + API key | Yes |
| Florence2MLXEngine | `florence2_mlx.py` | VLM (0.77B) | mlx-vlm, `<OCR_WITH_REGION>` | Yes |
| GlmOCREngine | `glm_ocr.py` | VLM (0.9B) | mlx-vlm | No |
| DotsOCREngine | `dots_ocr.py` | VLM (2.9B) | mlx-vlm | No |
| GeminiEngine | `gemini.py` | Cloud VLM | google-genai (Flash/Pro) | Yes |
## New optional dependency groups
panoocr[rapidocr] # RapidOCR + onnxruntime panoocr[google-vision] # Google Cloud Vision REST API panoocr[mlx-vlm] # Florence-2 MLX, GLM-OCR, DOTS.OCR panoocr[gemini] # Gemini API
## Notable implementation details
- **Florence-2 MLX** required a compatibility patch for `transformers` 5.x: registers `florence2_language` config type as `BartConfig` and disables stale remote code loading.
- **Gemini** returns per-detection bounding boxes via spatial grounding prompt (JSON with `[y1, x1, y2, x2]` in 0-1000 range), making it a structured engine despite being a VLM.
- **GLM-OCR** and **DOTS.OCR** confirmed as document-focused models that hallucinate on scene text — included as domain-mismatch controls for the paper.
- **RapidOCR** supports both v4 (2023, available when pipeline was built) and v5 (2025) via `config={"ocr_version": "PP-OCRv5"}`.
